### PR TITLE
Update glium dependency to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ keywords = ["glium", "vertex", "buffer", "typed"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-glium = "0.26"
+glium = "0.34.0"
 smallvec = "1.6.1"


### PR DESCRIPTION
This is required to update the glium dependency in the downstream binary rust-doom.